### PR TITLE
fix: 替换 themes 中山河文档的旧域名

### DIFF
--- a/themes/docsy/layouts/partials/footer.html
+++ b/themes/docsy/layouts/partials/footer.html
@@ -83,10 +83,10 @@
               <a href="https://www.shanhe.com/terms">服务条款</a>
             </li>
             <li>
-              <a href="https://docs.shanhe.com">使用文档</a>
+              <a href="https://docsv3.shanhe.com">使用文档</a>
             </li>
             <li>
-              <a href="https://docs.shanhe.com/product/faq/">常见问题</a>
+              <a href="https://docsv3.shanhe.com/product/faq/">常见问题</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
替换 themes 中山河文档的旧域名